### PR TITLE
fix incorrect return parameter in twitter_related

### DIFF
--- a/co-authors-plus-social-pack.php
+++ b/co-authors-plus-social-pack.php
@@ -115,7 +115,7 @@ class CoAuthors_Plus_Social_Pack {
 	 */
 	public function filter_jetpack_sharing_twitter_related( $related, $post_id ) {
 		if ( ! function_exists( 'get_coauthors' ) )
-			return $via;
+			return $related;
 
 		$coauthors = get_coauthors( $post_id );
 


### PR DESCRIPTION
The twitter_related function needs to return $related, not $via, when the plugin isn't loaded.
