### PR TITLE
Do not include 'via' account in the 'related' accounts

### DIFF
--- a/co-authors-plus-social-pack.php
+++ b/co-authors-plus-social-pack.php
@@ -122,9 +122,21 @@ class CoAuthors_Plus_Social_Pack {
 		if ( ! is_array( $coauthors ) || empty( $coauthors ) )
 			return $related;
 
+		$via = '';
+
+		// Determine the `via` value being used by Jetpack to avoid double-suggesting the first author's account.
+		if ( class_exists( 'Share_Twitter' ) && method_exists( 'Share_Twitter', 'sharing_twitter_via' ) ) {
+			$via = Share_Twitter::sharing_twitter_via( $post_id );
+		}
+
 		foreach ( $coauthors as $coauthor ) {
-			if ( ! isset( $coauthor->twitter ) || empty( $coauthor->twitter ) || ! (int) $coauthor->enable_twitter_related )
+			if ( ! isset( $coauthor->twitter ) || empty( $coauthor->twitter ) || ! (int) $coauthor->enable_twitter_related ) {
 				continue;
+			}
+
+			if ( $via === $coauthor->twitter ) {
+				continue;
+			}
 
 			$related[ $coauthor->twitter ] = $coauthor->description;
 		}


### PR DESCRIPTION
Blocked by https://github.com/Automattic/jetpack/pull/9339 . The Jetpack PR needs to be merged in order for this not to throw notices/warnings.

In testing, the value of `via` is always used as a "who to follow" suggested account, so if the same account is listed in both, Twitter displays both which looks messy and inhibits a second account from being suggested.

According to Twitter's documentation, the `via` account "may" be suggested, but my testing showed this to happen every time [(ref)](https://dev.twitter.com/web/tweet-button/web-intent)

This PR checks if the account is already used as the `via` and, if so, does not include it in the `related` array.

Bonus: We could check for Jetpack's version to avoid the warnings if a site is running modern CAP-SP and an older Jetpack, but since it won't fatal or negatively impact functionality, I lean on keeping the code clean of version checks.
