### PR TITLE
Update composer installer to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": ">=5.6",
-		"composer/installers": "~1.0"
+		"composer/installers": "^2.2"
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^2.2",


### PR DESCRIPTION
Resolved composer/installers conflicts error, as composer.json of this plugin use older version, while most of the other packages are using latest version.